### PR TITLE
Close resources so that ethereumj can survive hot reload

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/datasource/CachingDataSource.java
+++ b/ethereumj-core/src/main/java/org/ethereum/datasource/CachingDataSource.java
@@ -2,6 +2,7 @@ package org.ethereum.datasource;
 
 import org.ethereum.db.ByteArrayWrapper;
 
+import javax.annotation.PreDestroy;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -81,6 +82,7 @@ public class CachingDataSource implements KeyValueDataSource, Flushable {
     }
 
     @Override
+    @PreDestroy
     public void close() {
         source.close();
     }

--- a/ethereumj-core/src/main/java/org/ethereum/datasource/DataSource.java
+++ b/ethereumj-core/src/main/java/org/ethereum/datasource/DataSource.java
@@ -13,5 +13,6 @@ public interface DataSource {
     void init();
 
     boolean isAlive();
+
     void close();
 }

--- a/ethereumj-core/src/main/java/org/ethereum/datasource/DataSource.java
+++ b/ethereumj-core/src/main/java/org/ethereum/datasource/DataSource.java
@@ -13,6 +13,5 @@ public interface DataSource {
     void init();
 
     boolean isAlive();
-    
     void close();
 }

--- a/ethereumj-core/src/main/java/org/ethereum/datasource/LevelDbDataSource.java
+++ b/ethereumj-core/src/main/java/org/ethereum/datasource/LevelDbDataSource.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
+import javax.annotation.PreDestroy;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -227,7 +228,9 @@ public class LevelDbDataSource implements KeyValueDataSource {
     }
 
     @Override
+    @PreDestroy
     public void close() {
+        logger.info("close(): closing '{}' LevelDB datasource.", name);
         resetDbLock.writeLock().lock();
         try {
             if (!isAlive()) return;

--- a/ethereumj-core/src/main/java/org/ethereum/datasource/mapdb/MapDBDataSource.java
+++ b/ethereumj-core/src/main/java/org/ethereum/datasource/mapdb/MapDBDataSource.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
+import javax.annotation.PreDestroy;
 import java.io.File;
 import java.util.Map;
 import java.util.Set;
@@ -111,6 +112,7 @@ public class MapDBDataSource implements KeyValueDataSource {
     }
 
     @Override
+    @PreDestroy
     public void close() {
         db.close();
         alive = false;

--- a/ethereumj-core/src/main/java/org/ethereum/db/IndexedBlockStore.java
+++ b/ethereumj-core/src/main/java/org/ethereum/db/IndexedBlockStore.java
@@ -8,6 +8,7 @@ import org.hibernate.SessionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.PreDestroy;
 import java.io.*;
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -50,6 +51,25 @@ public class IndexedBlockStore extends AbstractBlockstore{
                 return new Block(bytes);
             }
         }).withCacheSize(256);
+    }
+
+    @PreDestroy
+    public void close() {
+        try {
+            logger.info("close(): closing indexDS");
+            indexDS.close();
+        }
+        catch (Exception e) {
+            logger.warn("close(): failed to indexDS because: "+e.getMessage(), e);
+        }
+
+        try {
+            logger.info("close(): closing blocksDS");
+            blocksDS.close();
+        }
+        catch (Exception e) {
+            logger.warn("close(): failed to blocksDS because: "+e.getMessage(), e);
+        }
     }
 
     public Block getBestBlock(){

--- a/ethereumj-core/src/main/java/org/ethereum/db/RepositoryImpl.java
+++ b/ethereumj-core/src/main/java/org/ethereum/db/RepositoryImpl.java
@@ -20,6 +20,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.FileSystemUtils;
 
 import javax.annotation.Nonnull;
+import javax.annotation.PreDestroy;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
@@ -117,16 +118,19 @@ public class RepositoryImpl implements Repository , org.ethereum.facade.Reposito
     }
 
     @Override
+    @PreDestroy
     public void close() {
         rwLock.writeLock().lock();
         try {
             if (detailsDB != null) {
+                logger.info("close(): closing detailsDB ...");
                 detailsDB.close();
                 detailsDB = null;
             }
 
 
             if (stateDB != null) {
+                logger.info("close(): closing stateDB ...");
                 stateDB.close();
                 stateDB = null;
             }

--- a/ethereumj-core/src/main/java/org/ethereum/db/TransactionStore.java
+++ b/ethereumj-core/src/main/java/org/ethereum/db/TransactionStore.java
@@ -2,7 +2,11 @@ package org.ethereum.db;
 
 import org.ethereum.datasource.*;
 import org.ethereum.core.TransactionInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
+
+import javax.annotation.PreDestroy;
 
 /**
  * Storage (tx hash) => (block idx, tx idx, TransactionReceipt)
@@ -11,6 +15,9 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class TransactionStore extends ObjectDataSource<TransactionInfo> {
+
+    private static final Logger logger = LoggerFactory.getLogger("general");
+
     private final static Serializer<TransactionInfo, byte[]> serializer =
             new Serializer<TransactionInfo, byte[]>() {
         @Override
@@ -35,5 +42,11 @@ public class TransactionStore extends ObjectDataSource<TransactionInfo> {
         if (getSrc() instanceof Flushable) {
             ((Flushable) getSrc()).flush();
         }
+    }
+
+    @PreDestroy
+    public void close() {
+        logger.info("destroy(): closing transaction store db");
+        getSrc().close();
     }
 }

--- a/ethereumj-core/src/main/java/org/ethereum/facade/EthereumFactory.java
+++ b/ethereumj-core/src/main/java/org/ethereum/facade/EthereumFactory.java
@@ -12,6 +12,9 @@ import org.ethereum.util.FileUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.stereotype.Component;
 
@@ -27,6 +30,7 @@ import java.util.List;
 public class EthereumFactory {
 
     private static final Logger logger = LoggerFactory.getLogger("general");
+    private static AnnotationConfigApplicationContext context = null;
 
     public static Ethereum createEthereum() {
         return createEthereum(SystemProperties.getDefault());
@@ -64,11 +68,17 @@ public class EthereumFactory {
         logger.info("capability shh version: [{}]", ShhHandler.VERSION);
         logger.info("capability bzz version: [{}]", BzzHandler.VERSION);
 
-        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+        context = new AnnotationConfigApplicationContext();
         context.getBeanFactory().registerSingleton("systemProperties", config);
         context.register(springConfigs);
         context.refresh();
         return context.getBean(Ethereum.class);
+    }
+
+    public static void close() {
+        logger.info("close(): closing Spring application context");
+        context.close();
+        context.registerShutdownHook();
     }
 
 }

--- a/ethereumj-core/src/main/java/org/ethereum/manager/WorldManager.java
+++ b/ethereumj-core/src/main/java/org/ethereum/manager/WorldManager.java
@@ -90,6 +90,7 @@ public class WorldManager {
 
     public void stopPeerDiscovery() {
         if (peerDiscovery.isStarted())
+            logger.info("stopPeerDiscovery(): ...");
             peerDiscovery.stop();
     }
 
@@ -195,9 +196,12 @@ public class WorldManager {
 
     @PreDestroy
     public void close() {
+        logger.info("close: stopping peer discovery ...");
         stopPeerDiscovery();
+        logger.info("close: closing main repository ...");
         repository.close();
-        blockchain.close();
+        logger.info("close: shutting down event dispatch thread used by EventBus ...");
+        EventDispatchThread.shutdown();
     }
 
 }

--- a/ethereumj-core/src/main/java/org/ethereum/net/peerdiscovery/PeerDiscovery.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/peerdiscovery/PeerDiscovery.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
 
+import javax.annotation.PreDestroy;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
@@ -83,9 +84,13 @@ public class PeerDiscovery {
         started.set(true);
     }
 
+    @PreDestroy
     public void stop() {
-        executorPool.shutdown();
-        monitor.shutdown();
+        logger.info("stopping executor pool");
+        if (executorPool != null) executorPool.shutdown();
+        logger.info("stopping monitor");
+        if (monitor != null) monitor.shutdown();
+        logger.info("shutting started flag to false");
         started.set(false);
     }
 

--- a/ethereumj-core/src/main/java/org/ethereum/net/server/ChannelManager.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/server/ChannelManager.java
@@ -21,6 +21,7 @@ import java.util.*;
 import java.util.concurrent.*;
 
 import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
 
 import static org.ethereum.net.message.ReasonCode.DUPLICATE_PEER;
 import static org.ethereum.net.message.ReasonCode.TOO_MANY_PEERS;
@@ -70,6 +71,16 @@ public class ChannelManager {
                 }
             }
         }, 0, 1, TimeUnit.SECONDS);
+    }
+
+    @PreDestroy
+    public void shutdown() {
+        mainWorker.shutdownNow();
+        try {
+            mainWorker.awaitTermination(10L, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            logger.warn("shutdown: mainWorker interrupted: {}", e.getMessage());
+        }
     }
 
     private void processNewPeers() {

--- a/ethereumj-core/src/main/java/org/ethereum/sync/strategy/LongSync.java
+++ b/ethereumj-core/src/main/java/org/ethereum/sync/strategy/LongSync.java
@@ -3,6 +3,7 @@ package org.ethereum.sync.strategy;
 import org.ethereum.core.BlockHeaderWrapper;
 import org.ethereum.net.server.Channel;
 import org.ethereum.sync.SyncState;
+import org.springframework.beans.factory.DisposableBean;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -26,7 +27,7 @@ import static org.ethereum.util.BIUtil.isIn20PercentRange;
  * @since 02.02.2016
  */
 @Component
-public class LongSync extends AbstractSyncStrategy {
+public class LongSync extends AbstractSyncStrategy implements DisposableBean {
 
     private static final int ROTATION_LIMIT = 100;
 
@@ -186,5 +187,11 @@ public class LongSync extends AbstractSyncStrategy {
         logger.info("Change state from {} to {}", state, newState);
 
         state = newState;
+    }
+
+    @Override
+    public void destroy() throws Exception {
+        logger.info("destroy(): destroying LongSync sync strategy");
+        stop();
     }
 }


### PR DESCRIPTION
Fixes ethereum/ethereumj#385 - close enough resources so that closing the Spring context releases all file locks plus shuts down as many thread pool executors as I could find